### PR TITLE
Fixed #1 : Modified Caption Formatting in .tex file

### DIFF
--- a/IISE Annual Conference Template.tex
+++ b/IISE Annual Conference Template.tex
@@ -72,7 +72,7 @@
     singlelinecheck=true,
     labelsep=colon,
     font={normalsize},
-    skip=10pt
+    skip=0pt
 }
 
 \captionsetup[figure]{
@@ -81,8 +81,10 @@
     singlelinecheck=true,
     labelsep=colon,
     font={normalsize},
-    skip=10pt
+    skip=0pt
 }
+
+\setlength{\textfloatsep}{12pt plus 2pt minus 4pt}
 
 %%%%% Bullet List Formatting %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \setlist[itemize,1]{label=\textbullet, leftmargin=0.5in}


### PR DESCRIPTION
Adjusted spacing settings for figures and captions such that only a single blank line is produced after a table/figure